### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-#MiniTwit
+# MiniTwit
 
 Java version of Flask's MiniTwit example built with the Spark web microframework, Freemarker, Spring and HSQLDB (as an in-memory database).
 
-##Prerequisites
+## Prerequisites
 
 - Java 8
 
 - Maven
 
-##How to run it
+## How to run it
 
 1. Clone the repository and go to the root directory.
 
@@ -18,7 +18,7 @@ Java version of Flask's MiniTwit example built with the Spark web microframework
 
 4. Log in as user001 with password user001, or user002/user002, or user003/user003 until user010/user010, or sign up yourself. If your e-mail address has an associated Gravatar image, this will be used as your profile image.
 
-##License
+## License
 MIT License
 
 See LICENSE for details.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
